### PR TITLE
Add dep on SDL that seems to be in shard.lock

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,4 +6,8 @@ authors:
 
 crystal: 0.21.1
 
+dependencies:
+  sdl:
+      github: ysbaddaden/sdl.cr
+
 license: MIT


### PR DESCRIPTION
Related to https://github.com/KCreate/stackvm/issues/3

This adds an SDL dependency that seems to be missing in the .yml but present in the .lock